### PR TITLE
Delivery For Crowd Source Reporter 6.1 Release (Sprint1/1)

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1412,6 +1412,7 @@ define([
                             }));
                             //clear graphics drawn on layer after feature has been submmited
                             if (this.featureGraphicLayer) {
+                                this.featureGraphicLayer.clear();
                             }
                         } catch (ex) {
                             this.appUtils.showError(ex.message);
@@ -2033,6 +2034,7 @@ define([
             graphic = new Graphic(graphicGeometry, symbol);
             // add graphics
             if (this.featureGraphicLayer) {
+                this.featureGraphicLayer.add(graphic);
             }
         },
 

--- a/js/main.js
+++ b/js/main.js
@@ -1411,7 +1411,8 @@ define([
                                 }
                             }));
                             //clear graphics drawn on layer after feature has been submmited
-                            this.featureGraphicLayer.clear();
+                            if (this.featureGraphicLayer) {
+                            }
                         } catch (ex) {
                             this.appUtils.showError(ex.message);
                         }
@@ -2031,7 +2032,8 @@ define([
             // create new graphic
             graphic = new Graphic(graphicGeometry, symbol);
             // add graphics
-            this.featureGraphicLayer.add(graphic);
+            if (this.featureGraphicLayer) {
+            }
         },
 
         /**


### PR DESCRIPTION
Resolved issue : #337 : BUG-000107645 In the ArcGIS Online Crowdsource Reporter app when the mobile display settings uses 'Show map first' and the app contains two or more web maps, submitting a report in mobile view shows the error 'Cannot read property 'clear' of null'.