### PR TITLE
Treat feature query errors the same as the case where there are no features

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,8 +41,8 @@
     <!-- Bootstrap TouchSpinner CSS -->
     <link rel="stylesheet" type="text/css" href="js/vendor/touch-spinner/jquery.bootstrap-touchspin.min.css" />
     <!--Dojo and Esri CSS-->
-    <link rel="stylesheet" href="https://js.arcgis.com/3.43/dijit/themes/claro/claro.css" />
-    <link rel="stylesheet" href="https://js.arcgis.com/3.43/esri/css/esri.css" />
+    <link rel="stylesheet" href="https://js.arcgis.com/3.44/dijit/themes/claro/claro.css" />
+    <link rel="stylesheet" href="https://js.arcgis.com/3.44/esri/css/esri.css" />
     <!-- Load any application specific styles -->
     <link rel="stylesheet" href="css/main.css" type="text/css" />
     <link rel="stylesheet" href="css/common.css" type="text/css" />
@@ -113,7 +113,7 @@
     <script type="text/javascript" src="js/vendor/bootstrap-datetimepicker/bootstrap-datetimepicker.min.js"></script>
     <script type="text/javascript" src="js/vendor/touch-spinner/jquery.bootstrap-touchspin.min.js"></script>
     <script type="text/javascript" src="js/vendor/exif/exif.js"></script>
-    <script type="text/javascript" src="https://js.arcgis.com/3.43"></script>
+    <script type="text/javascript" src="https://js.arcgis.com/3.44"></script>
     <script type="text/javascript">
         require([
                 "application/bootstrapper"

--- a/js/main.js
+++ b/js/main.js
@@ -326,7 +326,7 @@ define([
         */
         _checkSelfContent: function () {
             var withinFrame = window.location !== window.parent.location;
-            if (this.config.appResponse && 
+            if (this.config.appResponse &&
               !this._loggedInUser &&
               window.location.hostname.indexOf('arcgis.com') > -1 &&
               !withinFrame &&
@@ -1926,8 +1926,7 @@ define([
                 this._createFeature(result.features[0], layer, addedFrom);
                 featureDef.resolve();
             }), function (error) {
-                featureDef.reject();
-                console.log("Error :" + error);
+                featureDef.resolve();
             });
             return featureDef.promise;
         },
@@ -2751,7 +2750,8 @@ define([
             } else {
                 countQuery.where = "1=1";
             }
-            queryTask.executeForIds(countQuery, lang.hitch(this, function (results) {
+            queryTask.executeForIds(countQuery,
+              lang.hitch(this, function (results) {
                 //If server returns null values, set feature layer count to 0 and proceed
                 this.featureLayerCount = results && results.length ? results.length : 0;
                 //If geolocation exsists create configurable buffer and fetch the features
@@ -2767,9 +2767,13 @@ define([
                     //If geolocation does not exsists create feature batches
                     this._createFeatureBatches(featureLayer, results, details);
                 }
-            }), function (error) {
-                console.log(error);
-            });
+              }),
+              // Treat an error--which could be caused by the feature service having the setting "Editors can't
+              // see any features, even those they add" the same as if there are no features found
+              lang.hitch(this, function (error) {
+                this._createFeatureBatches(featureLayer, [], details);
+              })
+            );
         },
 
         /**


### PR DESCRIPTION
This is done because a feature service can be configured so that report submitters can't see their reports.

Two queries are affected:
1. when the app starts, all features are fetched 
2. after a user adds a report, all features are fetched again

If the report submitter can't see reports, the queries fail.

For the next release, we'd like to ask the feature service if it will accept queries and skip the impossible queries if it won't.

#546 